### PR TITLE
add www/img to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore all files
 *.*
+www/img/
 
 # Except
 !*.json


### PR DESCRIPTION
Fixes an image that gets bypassed due to not having an extension (`www/img/pictures/隠しフォルダ/ファイル_0008_0`)