### PR TITLE
Fix miyuki ending scene + extras (#4)

### DIFF
--- a/www/data/Map013.json
+++ b/www/data/Map013.json
@@ -17435,7 +17435,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "It would be nice if we could play a lot today too\\kw[1]"
+                                "It would be nice if we could\nplay a lot today too\\kw[1]"
                             ]
                         },
                         {

--- a/www/data/Map075.json
+++ b/www/data/Map075.json
@@ -2866,7 +2866,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "\\n[1]-kun's penis is also warm. ......\\"
+                                "\\n[1]-kun's penis is also warm. ......\\kw[1]"
                             ]
                         },
                         {
@@ -2900,7 +2900,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Inserting \\n[1]-kun's penis makes me feel very happy. ...\\"
+                                "Inserting \\n[1]-kun's penis makes me\nfeel very happy. ...\\kw[1]"
                             ]
                         },
                         {
@@ -3247,7 +3247,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "The penis is moving... ah... ahn..."
+                                "Your penis is moving... ah... ahn..."
                             ]
                         },
                         {
@@ -3264,7 +3264,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Pussy feels good."
+                                "My pussy feels good."
                             ]
                         },
                         {
@@ -3330,7 +3330,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "I want to feel good with Aunt's pussy, with lots of\ndicks\\kw[1]"
+                                "I want you to feel good with Aunt's pussy,\nwith your dick \\kw[1]"
                             ]
                         },
                         {
@@ -3469,7 +3469,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Ahh, ahh, ahh, amazing, penis, penis feels good."
+                                "Ahh, ahh, ahh, amazing, penis...\nyour penis feels good!"
                             ]
                         },
                         {
@@ -3535,7 +3535,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Is it good? Shall I let it out?"
+                                "Is it good?\nDo you want to let it out?"
                             ]
                         },
                         {
@@ -3813,7 +3813,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "......Huh? \\.This time from behind? ...?"
+                                "......Huh? \\kw[1].This time from behind? ...?"
                             ]
                         },
                         {
@@ -3854,7 +3854,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "That's good, \\n[1]-kun \\kw[1]\\.. Once again, with your erect\npenis... \\kw[1]"
+                                "That's good, \\n[1]-kun \\kw[1]\\.. Once again, with\nyour erect penis... \\kw[1]"
                             ]
                         },
                         {
@@ -4247,7 +4247,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Animal-like sex ...\\. I like it .... Ahh ... \\kw[2] \\kw[1]."
+                                "Animal-like sex ...\\kw[1]. I like it .... Ahh ... \\kw[2] \\kw[1]."
                             ]
                         },
                         {
@@ -4296,7 +4296,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Not an obligatory ... child-making, but ... \\kw[1]."
+                                "Not just an obligatory ... child-making, but ... \\kw[1]."
                             ]
                         },
                         {
@@ -4313,7 +4313,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Just a ...\\kw[1]\\.ngh\\kw[1]\\.. Not just for sexual release\n...h\\kw[2]."
+                                "Not just a ...\\kw[1]\\.ngh\\kw[1]\\.. Not just\nfor sexual release...h\\kw[2]."
                             ]
                         },
                         {
@@ -4413,7 +4413,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "It feels like digging around inside ... and \\., yes ... and\n\\kw[1]\\., that's right ... and \\kw[2]."
+                                "It feels like digging around inside ... and \\kw[1].\nYes ... and \\kw[2], that's right ... yes \\kw[2]."
                             ]
                         },
                         {
@@ -4486,7 +4486,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Auntie, I'm going to cum ... \\kw[1]."
+                                "Auntie is going to cum ... \\kw[1]."
                             ]
                         },
                         {
@@ -4838,7 +4838,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "\\n[1]-kun ...\\ [v1]"
+                                "\\n[1]-kun ...\\kw[1]"
                             ]
                         },
                         {
@@ -5050,7 +5050,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Mmm... slurp... slurp... slurp... lick... slurp... rub..."
+                                "Mmm... slurp... slurp...\nslurp... lick... slurp... rub..."
                             ]
                         },
                         {
@@ -5116,7 +5116,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "...Jeez\\kw[1], even though I came twice already, it's gotten\nthis big again...\\kw[1]."
+                                "...Jeez\\kw[1], even though you came twice already,\nit's gotten this big again...\\kw[1]."
                             ]
                         },
                         {
@@ -5150,7 +5150,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "The penis is delicious ... *slurp* \\kw[1] *slurp* *lick*\n*slurp* ... *slurp* \\kw[1]"
+                                "The penis is delicious ... *slurp* \\kw[1]\n*slurp* *lick* *slurp* ... *slurp* \\kw[1]"
                             ]
                         },
                         {
@@ -5216,7 +5216,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "\\n[1]-kun's penis, I wouldn't mind keeping it in my mouth\nforever. ..."
+                                "\\n[1]-kun's penis, I wouldn't mind keeping it\nin my mouth forever. ..."
                             ]
                         },
                         {
@@ -5233,7 +5233,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Even when I'm cooking rice ..., even when I'm doing the\nlaundry ... \\kw[1]"
+                                "Even when I'm cooking rice ..., even when\nI'm doing the laundry ... \\kw[1]"
                             ]
                         },
                         {
@@ -5250,7 +5250,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "If you show me your penis, I'll immediately put it in my\nmouth. *slurp* *lick* *mm* *ahh*."
+                                "If you show me your penis, I'll immediately put it\nin my mouth. *slurp* *lick* *mm* *ahh*."
                             ]
                         },
                         {
@@ -5356,7 +5356,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "......Already\\kw[1]"
+                                "......Him? \\kw[1]"
                             ]
                         },
                         {
@@ -5373,7 +5373,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "......I wouldn't do such a thing to that person. \\kw[1]"
+                                "......I wouldn't do such a thing\nwith that person. \\kw[1]"
                             ]
                         },
                         {
@@ -5390,7 +5390,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "The only thing I like is \\n[1]-kun's penis. ......\\kw[1]"
+                                "The only thing I like is\n\\n[1]-kun's penis. ......\\kw[1]"
                             ]
                         },
                         {
@@ -5407,7 +5407,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Even if asked, I won't put that person's in my mouth, so\n...\\kw[1]"
+                                "Even if asked, I won't put that\nperson's in my mouth, so ...\\kw[1]"
                             ]
                         },
                         {
@@ -5441,7 +5441,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "*slurp* *lick* *slurp* *suck* *mm* \\kw[1] *smack* \\kw[1]\n*moan* ...\\ ...\\"
+                                "*slurp* *lick* *slurp* *suck* *mm* \\kw[1]\n*smack* \\kw[1] *moan* ...\\kw[1] ...\\kw[1]"
                             ]
                         },
                         {
@@ -5551,7 +5551,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "......Hehe\\kw[1]\\. Will you make me feel good again,\nAuntie?...?\\kw[1]"
+                                "......Hehe\\kw[1]\\. Will you make Auntie\nfeel good again?...?\\kw[1]"
                             ]
                         },
                         {
@@ -5602,7 +5602,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "In the anus, ......, \\., right? \\kw[1]"
+                                "In the butt, ......, \\kw[1], right? \\kw[1]"
                             ]
                         },
                         {
@@ -5884,7 +5884,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "\\n[1]-kun..., still full of energy like this...\\kw[1]\\..\nAh\\kw[1], oh\\kw[2]."
+                                "\\n[1]-kun..., still full of energy like\nthis...\\kw[1]\\.. Ah\\kw[1], oh\\kw[2]."
                             ]
                         },
                         {
@@ -5923,7 +5923,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "No, stop \\kw[1]. I'm going to cum \\kw[1]\\.. I'm cumming\n\\kw[1] with my butt \\kw[1]. Ohhh \\kw[2]."
+                                "No, stop \\kw[1]. I'm going to cum \\kw[2].\nI'm cumming\\kw[1] with my butt \\kw[1]. Ohhh \\kw[2]."
                             ]
                         },
                         {
@@ -6088,7 +6088,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Ah, ah, no, if you move your hips while I'm in the middle of\nclimaxing, I..."
+                                "Ah, ah, no, if you move your hips while\nI'm in the middle of climaxing, I..."
                             ]
                         },
                         {
@@ -6260,7 +6260,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Oh... oh... I'm peeing... it's coming out... ah... nngh..."
+                                "Oh... oh... I'm peeing...\nit's coming out... ah... nngh..."
                             ]
                         },
                         {
@@ -6299,7 +6299,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Ah, no, Auntie, not this, ah"
+                                "Ah, no, in your Auntie, not this, ah"
                             ]
                         },
                         {
@@ -6316,7 +6316,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Doing it with the butt ... makes my mind go blank ...\n\\kw[2]."
+                                "Doing it with my butt ...\nmakes my mind go blank ...\\kw[2]."
                             ]
                         },
                         {
@@ -6368,7 +6368,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "It feels good... My penis feels good... Oh... Oh..."
+                                "It feels good... Your penis feels good... Oh... Oh..."
                             ]
                         },
                         {
@@ -6522,7 +6522,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Using the butt and pussy, ah, I'm going to cum again."
+                                "Using my butt and pussy,\nah, I'm going to cum again."
                             ]
                         },
                         {
@@ -7445,7 +7445,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "The whole house is echoing, but is there any way to make it\nquieter?"
+                                "The whole house is echoing,\nis there any way to make it quieter?"
                             ]
                         },
                         {
@@ -7516,7 +7516,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Especially mom! \\. Your voice is too loud!"
+                                "Especially mom! \\kw[1].\nYour voice is too loud!"
                             ]
                         },
                         {
@@ -7702,7 +7702,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "It's impossible to hold back ...\\kw[1]\\. ......\\kw[2]"
+                                "It's impossible to hold back ...\n\\kw[1]\\. ......\\kw[2]"
                             ]
                         },
                         {
@@ -8179,7 +8179,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "It's fine, it's not a big deal. ...\\"
+                                "It's fine, it's not a\nbig deal. ...\\kw[1]"
                             ]
                         },
                         {
@@ -8196,7 +8196,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "I'm the one who ......\\. shamelessly moaned ...\\kw[1]"
+                                "I'm the one who ......\\kw[1]\nshamelessly moaned ...\\kw[1]"
                             ]
                         },
                         {
@@ -8516,7 +8516,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "You also take the initiative to help with household chores\n..."
+                                "You also take the initiative to\nhelp with household chores..."
                             ]
                         },
                         {
@@ -8533,7 +8533,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Even though there is an age difference, you love me a lot."
+                                "Even though there is an age\ndifference, you love me a lot."
                             ]
                         },
                         {
@@ -8594,7 +8594,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Since \\n[1]-kun started coming to my house, \\. I feel really\nfulfilled. \\kw[1]"
+                                "Since \\n[1]-kun started coming to my house, \\kw[1]\nI feel really fulfilled. \\kw[1]"
                             ]
                         },
                         {
@@ -8944,7 +8944,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "......Hehe\\kw[1]\\. Thank you, \\n[1]-kun\\kw[1]"
+                                "......Hehe\\kw[2]. Thank you, \\n[1]-kun\\kw[1]"
                             ]
                         },
                         {
@@ -9064,7 +9064,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "I can't keep relying on you to help me forever, right?"
+                                "I can't keep relying on you\nto help me forever, right?"
                             ]
                         },
                         {
@@ -9263,7 +9263,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Should I go to \\n[1]-kun's house to help out next time?"
+                                "Should I go to \\n[1]-kun's house\nto help out next time?"
                             ]
                         },
                         {
@@ -9551,7 +9551,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "When \\n[1]-kun starts living alone, a long, long time from\nnow."
+                                "When \\n[1]-kun starts living alone,\na long, long time from now."
                             ]
                         },
                         {
@@ -9932,7 +9932,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Oh no! \\. It's already this late!"
+                                "Oh no! \\kw[1]. It's already this late!"
                             ]
                         },
                         {
@@ -9981,7 +9981,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "I was so absorbed in \\n[1]-kun that I completely forgot about\ndinner. ...\\"
+                                "I was so absorbed in \\n[1]-kun that I\ncompletely forgot about dinner. ...\\kw[1]"
                             ]
                         },
                         {
@@ -10078,7 +10078,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Hehe \\kw[1]\\. Thank you, \\n[1]-kun \\kw[1]"
+                                "Hehe \\kw[2]. Thank you, \\n[1]-kun \\kw[1]"
                             ]
                         },
                         {
@@ -10221,7 +10221,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Should we make some rejuvenating \\c[14]softshell turtle hot\npot\\c[0], I wonder? ......\\kw[1]"
+                                "Should we make some rejuvenating \\c[14]softshell\nturtle hot pot\\c[0], I wonder? ......\\kw[1]"
                             ]
                         },
                         {
@@ -10413,7 +10413,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Shall we continue after we finish eating? ......? \\kw[1]"
+                                "Shall we continue after we\nfinish eating? ......? \\kw[1]"
                             ]
                         },
                         {

--- a/www/data/Map120.json
+++ b/www/data/Map120.json
@@ -1795,7 +1795,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "My penis gets erect immediately with sperm ......."
+                                "My penis gets erect immediately and starts leaking ......."
                             ]
                         },
                         {
@@ -2150,7 +2150,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Before I cum on your breasts, my penis might explode, you\nknow?"
+                                "Before you cum on my breasts, your\npenis might explode, you know?"
                             ]
                         },
                         {
@@ -2527,7 +2527,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Shall we take off our pants? ...\\ [v1]"
+                                "Shall we take off\nyour pants? ...\\kw[1]"
                             ]
                         },
                         {
@@ -2629,7 +2629,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "With my onee-chan's breasts"
+                                "With onee-chan's breasts"
                             ]
                         },
                         {
@@ -2678,7 +2678,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Penis ...\\kw[1]\\., feel good a lot, okay... ...\\kw[1]"
+                                "Penis ...\\kw[1], feel good a lot,\nokay... ...\\kw[1]"
                             ]
                         },
                         {
@@ -2993,7 +2993,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Are you taking proper pictures?"
+                                "Are you taking\nproper pictures?"
                             ]
                         },
                         {
@@ -3103,7 +3103,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "\\n[1]'s penis, which had taken off his pants and exposed his\nlower body, is enveloped by Shizuku's large breasts."
+                                "\\n[1], who had taken off his pants and exposed his penis,\nis enveloped by Shizuku's large breasts."
                             ]
                         },
                         {
@@ -3120,7 +3120,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Using the camera of the smartphone borrowed from Shizuku,\npress the record button to capture those large breasts\nwithin the frame. \\c[14]"
+                                "Using the camera of the smartphone borrowed from Shizuku,\nhe pressed the record button to capture those large breasts\nwithin the frame. \\c[14]"
                             ]
                         },
                         {
@@ -3179,7 +3179,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "It's been a while since we had a photo shoot like this,\nhasn't it?"
+                                "It's been a while since we had a photo\nshoot like this, hasn't it?"
                             ]
                         },
                         {
@@ -3231,7 +3231,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "I get excited when I think that I'm being photographed."
+                                "I get excited when I think that\nI'm being photographed."
                             ]
                         },
                         {
@@ -3647,7 +3647,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "\\n[1]'s penis becomes even stronger inside Shizuku's breasts,\nimagining that the days of repeatedly mating have shaped the\ncurrent Shizuku."
+                                "\\n[1]'s penis becomes even harder inside Shizuku's breasts,\nimagining that the days of repeatedly mating have shaped the\ncurrent Shizuku."
                             ]
                         },
                         {
@@ -3835,7 +3835,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Penis ...\\kw[1]\\. jumped with a twitch ...\\kw[1]"
+                                "Penis ...\\kw[1]\\. jumped with\na twitch ...\\kw[1]"
                             ]
                         },
                         {
@@ -4200,7 +4200,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Are you not going to shake your hips and struggle anymore?"
+                                "Are you not going to shake your\nhips and struggle anymore?"
                             ]
                         },
                         {
@@ -4372,7 +4372,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "I can't help it anymore, you know."
+                                "I can't help it\nanymore, you know."
                             ]
                         },
                         {
@@ -4453,7 +4453,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "The feeling of a woman's bare breasts."
+                                "The feeling of a\nwoman's bare breasts."
                             ]
                         },
                         {
@@ -4832,7 +4832,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "The feeling of my onee-chan's bare breasts after half a\nyear. ...\\kw[1]"
+                                "The feeling of onee-chan's bar\n breasts after half a year. ...\\kw[1]"
                             ]
                         },
                         {
@@ -5077,7 +5077,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Mmm... because you're such a troublemaker..."
+                                "Mmm... because you're such\na troublemaker..."
                             ]
                         },
                         {
@@ -5094,7 +5094,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "It's fine. Adjusting to \\n[1]-kun's penis."
+                                "It's fine. Adjusting to\n\\n[1]-kun's penis."
                             ]
                         },
                         {
@@ -5111,7 +5111,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "I'll move my onee-chan's breasts for you."
+                                "I'll move onee-chan's\nbreasts for you."
                             ]
                         },
                         {
@@ -5357,7 +5357,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Hehe, it's making a really naughty sound."
+                                "Hehe, it's making a really\nnaughty sound."
                             ]
                         },
                         {
@@ -5374,7 +5374,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "I'll let you hear it more so that it's recorded properly,\nokay?"
+                                "I'll let you hear it more so that it's\nrecorded properly, okay?"
                             ]
                         },
                         {
@@ -5520,7 +5520,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Ah! Ah! \\. That feels good!"
+                                "Ah! Ah! \\kw[1]. That feels good!"
                             ]
                         },
                         {
@@ -5577,7 +5577,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "The breasts make a vulgar sound as if they are chewing on\npleasure juice, resonating throughout Shizuku's room."
+                                "The breasts make a vulgar sound as if they are chewing on\nprecum, resonating throughout Shizuku's room."
                             ]
                         },
                         {
@@ -5681,7 +5681,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "A very lewd scent is coming from between the breasts.\n...\\kw[1]"
+                                "A very lewd scent is coming from\nbetween my breasts. ...\\kw[1]"
                             ]
                         },
                         {
@@ -5765,7 +5765,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Come on, don't hold back, okay?"
+                                "Come on, don't hold\nback, okay?"
                             ]
                         },
                         {
@@ -5782,7 +5782,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "It's been half a year since I've seen my onee-chan's bare\nbreasts."
+                                "It's been half a year since you've\nseen onee-chan's bare breasts."
                             ]
                         },
                         {
@@ -5799,7 +5799,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Shall we release a lot of semen with a splash?"
+                                "Shall we release a lot\nof semen with a splash?"
                             ]
                         },
                         {
@@ -6096,7 +6096,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "It's been half a year since ... \\kw[1] \\.. Let's make a mess\ntogether ... \\kw[2]."
+                                "It's been half a year since ... \\kw[2]..\nLet's make a mess together ... \\kw[2]."
                             ]
                         },
                         {
@@ -6393,7 +6393,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Onee-chan's breasts. Let's do a lot of creampie."
+                                "Onee-chan's breasts.\nLet's do a lot of creampie."
                             ]
                         },
                         {
@@ -6971,7 +6971,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Hehe, a lot came out, didn't it..."
+                                "Hehe, a lot came out,\ndidn't it..."
                             ]
                         },
                         {
@@ -7030,7 +7030,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "How about it? Long time no titty fuck."
+                                "How about it? Long\ntime no titty fuck."
                             ]
                         },
                         {
@@ -7296,7 +7296,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "\\c[14]Ah! Ah! \\. That feels ... good ......!"
+                                "\\c[14]Ah! Ah! \\kw[1]. That feels ... good ......!"
                             ]
                         },
                         {
@@ -7400,7 +7400,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "......Hehe\\kw[1]\\., it's being recorded properly, isn't\nit?\\kw[1]"
+                                "......Hehe\\kw[1]\\., it's being recorded\nproperly, isn't it?\\kw[1]"
                             ]
                         },
                         {
@@ -7808,7 +7808,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "SZRIN's material that can be used anytime ......\\kw[1]"
+                                "SZRIN's material that can be\nused anytime ......\\kw[1]"
                             ]
                         },
                         {
@@ -7847,7 +7847,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "It increased again, huh?"
+                                "It's hard again, huh?"
                             ]
                         },
                         {
@@ -8059,7 +8059,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "\\n[1]-kun, you're getting excited again. ......\\"
+                                "\\n[1]-kun, you're getting\nexcited again. ......\\kw[1]"
                             ]
                         },
                         {
@@ -8076,7 +8076,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Wasn't once not enough after all, I wonder? ...? \\kw[1]"
+                                "Wasn't once not enough after\nall, I wonder? ...? \\kw[1]"
                             ]
                         },
                         {
@@ -8203,7 +8203,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "Let's have more and more erotic photoshoots with SZRIN,\nokay!"
+                                "Let's have more and more erotic\nphotoshoots with SZRIN, okay!"
                             ]
                         },
                         {
@@ -8220,7 +8220,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "I want to have a lot of pleasure with many penises!"
+                                "I want to have a lot of pleasure with my penis!"
                             ]
                         },
                         {
@@ -8389,7 +8389,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "We have time until night, so shall we do it a lot? ......"
+                                "We have time until night, so shall\nwe do it a lot? ......"
                             ]
                         },
                         {
@@ -8495,7 +8495,7 @@
                             "code": 401,
                             "indent": 0,
                             "parameters": [
-                                "\\n[1]-kun's computer is getting full in terms of storage\ncapacity."
+                                "\\n[1]-kun's computer is getting full\nin terms of storage capacity."
                             ]
                         },
                         {


### PR DESCRIPTION
* Cleanup translation in the miyuki ending scene related to pronouns and awkward phrasing
* Fix text formatting in the miyuki ending scene so the text doesnt cover the actors
* Fix broken and missing control codes in miyuki ending scene
* Fixes shizuku scene translations and text positioning. Turns out she does have a sister, but shes not in (that) scene
* Fix other minor mistranslations found at the same time